### PR TITLE
Port to Zig 0.14.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 zig-cache
+.zig-cache
 zig-out
 .DS_Store
 rom

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ The emulation is cycle accurate (as accurate as I could make it), and the code w
 A secondary goal of this project is to be a learning resource for anyone wanting to write their
 own emulator.
 
-> **NOTE**: This repo is compatible with Zig v0.12.1.
-> Should also work with Zig <= 0.14.0, but I haven't tested it.
+> **NOTE**: This repo is compatible with Zig v0.14.0.
 
 <div style="display: flex; gap: 10px;">
     <img src="./screens/megaman_gameplay.gif" alt="Megaman gameplay" width="320px"/>

--- a/build.zig
+++ b/build.zig
@@ -1,37 +1,29 @@
 const std = @import("std");
 
-pub fn build(b: *std.Build) !void {
+pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const exe = b.addExecutable(.{
-        .name = "nez",
+    const exe_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
-    b.installArtifact(exe);
 
-    if (target.result.isDarwin() and !target.query.isNative()) {
-        if (b.sysroot == null) {
-            @panic(" Pass --sysroot <path/to/macOS/SDK>");
-        }
-        exe.addSystemIncludePath(b.path(b.pathJoin(&.{ b.sysroot.?, "/usr/include" })));
-        exe.addLibraryPath(b.path(b.pathJoin(&.{ b.sysroot.?, "/usr/lib" })));
-        exe.addFrameworkPath(b.path(b.pathJoin(&.{ b.sysroot.?, "/System/Library/Frameworks" })));
-    }
+    const exe = b.addExecutable(.{
+        .name = "nez",
+        .root_module = exe_mod,
+    });
 
     const raylib_dep = b.dependency("raylib", .{
         .target = target,
         .optimize = optimize,
     });
 
-    exe.root_module.strip = b.option(
-        bool,
-        "strip",
-        "Strip debug info to reduce binary size, defaults to false",
-    ) orelse false;
-    exe.linkLibrary(raylib_dep.artifact("raylib"));
+    const raylib = raylib_dep.artifact("raylib");
+    exe.linkLibrary(raylib);
+
+    b.installArtifact(exe);
 
     const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
@@ -43,14 +35,12 @@ pub fn build(b: *std.Build) !void {
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
 
-    const unit_tests = b.addTest(.{
-        .root_source_file = b.path("src/main.zig"),
-        .target = target,
-        .optimize = optimize,
+    const exe_unit_tests = b.addTest(.{
+        .root_module = exe_mod,
     });
 
-    const run_unit_tests = b.addRunArtifact(unit_tests);
+    const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
 
     const test_step = b.step("test", "Run unit tests");
-    test_step.dependOn(&run_unit_tests.step);
+    test_step.dependOn(&run_exe_unit_tests.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,16 +6,14 @@
     //
     // It is redundant to include "zig" in this name because it is already
     // within the Zig package namespace.
-    .name = "nez",
+    .name = .nez,
 
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
     .version = "0.0.1",
 
-    // This field is optional.
-    // This is currently advisory only; Zig does not yet do anything
-    // with this value.
-    //.minimum_zig_version = "0.11.0",
+    .fingerprint = 0x155238f83225f865, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.14.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
@@ -24,19 +22,10 @@
     // internet connectivity.
     .dependencies = .{
         .raylib = .{
-            .url = "https://github.com/raysan5/raylib/archive/52f2a10db610d0e9f619fd7c521db08a876547d0.tar.gz",
-            .hash = "122078ad3e79fb83b45b04bd30fb63aaf936c6774db60095bc6987d325cbe5743373",
+            .url = "git+https://github.com/raysan5/raylib.git#7e072783683e8449c70e39148c4ac5ccc2ae8c49",
+            .hash = "raylib-5.5.0-whq8uIW6NASN0CAB59Hlfvy7en7Bm3UGFRgwcy-zgkAS",
         },
     },
-
-    // Specifies the set of files and directories that are included in this package.
-    // Only files and directories listed here are included in the `hash` that
-    // is computed for this package. Only files listed here will remain on disk
-    // when using the zig package manager. As a rule of thumb, one should list
-    // files required for compilation plus any license(s).
-    // Paths are relative to the build root. Use the empty string (`""`) to refer to
-    // the build root itself.
-    // A directory listed here means that all files within, recursively, are included.
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/ppu/ppu.zig
+++ b/src/ppu/ppu.zig
@@ -183,7 +183,7 @@ pub const PPU = struct {
     mapper: *Mapper,
 
     /// Internal latches that store sprite data for the current scanline.
-    sprites_on_scanline: [8]Sprite = .{.{}} ** 8,
+    sprites_on_scanline: [8]Sprite = [_]Sprite{.{}} ** 8,
 
     const Self = @This();
 
@@ -706,7 +706,7 @@ pub const PPU = struct {
 
                 if (tall_sprites and
                     ((is_second_half and !attrs.flip_vert) or
-                    (!is_second_half and attrs.flip_vert)))
+                        (!is_second_half and attrs.flip_vert)))
                 {
                     tile_index = @addWithOverflow(tile_index, 1)[0];
                 }


### PR DESCRIPTION
`.gitignore` - added .zig-cache - looks like it is generated by v0.14.0
`README.md` - updated description
`build.zig` - re-generated by 0.14.0 and keep only the needed similar to the old one