### PR TITLE
fix: resolve build failures on Zig 0.16.0-dev

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -58,26 +58,4 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_exe_unit_tests.step);
 
-    // Minimal raylib test target
-    const test_mod = b.createModule(.{
-        .root_source_file = b.path("src/main_test.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-    test_mod.linkLibrary(raylib);
-    if (target.result.os.tag == .macos) {
-        test_mod.linkFramework("OpenGL", .{});
-        test_mod.linkFramework("Cocoa", .{});
-        test_mod.linkFramework("CoreAudio", .{});
-        test_mod.linkFramework("CoreVideo", .{});
-    }
-    const test_exe = b.addExecutable(.{
-        .name = "raylib-test",
-        .root_module = test_mod,
-    });
-    b.installArtifact(test_exe);
-    const test_run_cmd = b.addRunArtifact(test_exe);
-    test_run_cmd.step.dependOn(b.getInstallStep());
-    const test_run_step = b.step("test-raylib", "Run minimal raylib test");
-    test_run_step.dependOn(&test_run_cmd.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -22,8 +22,8 @@
     // internet connectivity.
     .dependencies = .{
         .raylib = .{
-            .url = "git+https://github.com/raysan5/raylib.git",
-            .hash = "raylib-5.6.0-dev-whq8uNSYJwUA6SlXhKDsitkuySZYi6Zn3IlzusX1AIot",
+            .url = "git+https://github.com/raysan5/raylib.git#c5fc7716229cef1727e7baf325a695a0ac00cf27",
+            .hash = "raylib-5.6.0-dev-whq8uKYzLgX-q-In4VEd9Fqecm5-vtyd5tGHKFpQKoLr",
         },
     },
     .paths = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -94,10 +94,10 @@ fn rlAudioInputCallback(buffer_: ?*anyopaque, frames: c_uint) callconv(.c) void 
 }
 
 pub fn main(init: std.process.Init.Minimal) !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
+    var dbg = std.heap.DebugAllocator(.{}){};
+    defer _ = dbg.deinit();
 
-    const allocator = gpa.allocator();
+    const allocator = dbg.allocator();
 
     var args = std.process.Args.Iterator.init(init.args);
     _ = args.skip();


### PR DESCRIPTION
## Summary

- **Pin raylib dependency to valid commit ref** (`c5fc771`): the previous ref `raylib-5.6.0-dev` does not exist in the raylib repository, causing `zig build` to fail with `ref not found`.
- **Replace `GeneralPurposeAllocator` with `DebugAllocator`** in `src/main.zig`: `GeneralPurposeAllocator` was removed from `std.heap` in Zig 0.16.0-dev.
- **Remove `raylib-test` build target** from `build.zig`: it references the already-deleted `src/main_test.zig`, causing a `FileNotFound` error.

## Test plan

- [ ] `zig build` compiles successfully on Zig 0.16.0-dev
- [ ] `zig build run` launches the emulator without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)